### PR TITLE
openssl speed uses cpu time by default

### DIFF
--- a/test/perf_cpu
+++ b/test/perf_cpu
@@ -3,5 +3,5 @@
 require_relative "../lib/ferret"
 
 bash(name: :blowfish, stdin: <<'EOF')
-  openssl speed blowfish
+  openssl speed rsa -elapsed -mr
 EOF


### PR DESCRIPTION
Wall clock time is more important to us. Plus, there's a "machine readable format" option available, which might make it easier for us to log throughputs later.
